### PR TITLE
Fixed logging order. Now logs grid state before applying move

### DIFF
--- a/app/src/main/java/Bamboo/model/Game.java
+++ b/app/src/main/java/Bamboo/model/Game.java
@@ -38,8 +38,6 @@ public class Game
     {
         if(grid.isLegalMove(v, currentPlayer.getColor()))
         {
-            grid.setTile(v, currentPlayer.getColor());
-
             if(LOG_MOVES)
             {
                 int[] X = DataManager.flatten(grid, currentPlayer.getColor());
@@ -47,7 +45,9 @@ public class Game
                 String data = DataManager.concatToCSV(X, Y);
                 Logger.logCSV("data.csv", data);
             }
-            
+
+            grid.setTile(v, currentPlayer.getColor());
+
             toggleTurn();
         }
         if(grid.isFinished(currentPlayer.getColor()))


### PR DESCRIPTION
In Game, the current grid state was logged after applying the chosen move. Therefore, the training data for NN would be meaningless since it would always suggest making a move that has already been made.